### PR TITLE
Ah ha, version of gfortran wasnt putting the files .gcda and .gcno fi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,5 +123,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./tests/unit_tests/
+          #directory: ./tests/unit_tests/
           gcov: true


### PR DESCRIPTION
…les in the root directory. now it is, commented directory out