### PR TITLE
Annoyingly the coverage didn't drop after we added the productCustom …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 
 # set compilation flags for each compiler
 ifeq ($(FORTC),"gnu")
-FFLAGS       =  -O2 -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
+FFLAGS       =  -fprofile-arcs -ftest-coverage -ffree-form -fimplicit-none -Wall -Wpedantic -fcheck=all -fPIC
 FSHAREDFLAGS =  -ffree-line-length-none -ffree-form -fimplicit-none -Wall -Wpedantic -Wno-unused-dummy-argument -fcheck=all -fPIC -shared
 endif
 ifeq ($(FORTC),"intel")


### PR DESCRIPTION
…function, I suspect the compiler editted it out as it was never called. Trying to remove -O2 to see if that helps